### PR TITLE
APB-9429 Bootstrap upgrade

### DIFF
--- a/app/uk/gov/hmrc/agentauthorisation/connectors/PlatformAnalyticsConnector.scala
+++ b/app/uk/gov/hmrc/agentauthorisation/connectors/PlatformAnalyticsConnector.scala
@@ -39,11 +39,10 @@ trait PlatformAnalyticsConnector {
 class PlatformAnalyticsConnectorImpl @Inject() (appConfig: AppConfig, http: HttpClientV2)
     extends PlatformAnalyticsConnector with HttpErrorFunctions {
 
-  val serviceUrl: String = s"${appConfig.platformAnalyticsBaseUrl}/platform-analytics/event"
-
-  def sendEvent(request: AnalyticsRequest)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Done] =
+  def sendEvent(request: AnalyticsRequest)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Done] = {
+    val requestUrl = url"${appConfig.platformAnalyticsBaseUrl}/platform-analytics/event"
     http
-      .post(url"$serviceUrl")
+      .post(requestUrl)
       .withBody(Json.toJson(request))
       .execute[HttpResponse]
       .map { response =>
@@ -58,4 +57,5 @@ class PlatformAnalyticsConnectorImpl @Inject() (appConfig: AppConfig, http: Http
         Logger(getClass).warn(s"Couldn't send analytics event, error: $ex")
         Done
       }
+  }
 }

--- a/app/uk/gov/hmrc/agentauthorisation/connectors/RelationshipsConnector.scala
+++ b/app/uk/gov/hmrc/agentauthorisation/connectors/RelationshipsConnector.scala
@@ -23,10 +23,9 @@ import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, Vrn}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.client.HttpClientV2
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, UpstreamErrorResponse}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps, UpstreamErrorResponse}
 import uk.gov.hmrc.play.bootstrap.metrics.Metrics
 
-import java.net.URL
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -37,18 +36,9 @@ class RelationshipsConnector @Inject() (httpClient: HttpClientV2, val metrics: M
 
   val acrUrl = s"${appConfig.acrBaseUrl}/agent-client-relationships"
 
-  private[connectors] def checkItsaRelationshipUrl(arn: Arn, nino: Nino): URL =
-    new URL(s"$acrUrl/agent/${arn.value}/service/HMRC-MTD-IT/client/NI/${nino.value}")
-
-  private[connectors] def checkItsaSuppRelationshipUrl(arn: Arn, nino: Nino): URL =
-    new URL(s"$acrUrl/agent/${arn.value}/service/HMRC-MTD-IT-SUPP/client/NI/${nino.value}")
-
-  private[connectors] def checkVatRelationshipUrl(arn: Arn, vrn: Vrn): URL =
-    new URL(s"$acrUrl/agent/${arn.value}/service/HMRC-MTD-VAT/client/VRN/${vrn.value}")
-
   def checkItsaRelationship(arn: Arn, nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Boolean] =
     monitor(s"ConsumedAPI-Check-ItsaRelationship-GET") {
-      val requestUrl = checkItsaRelationshipUrl(arn, nino)
+      val requestUrl = url"$acrUrl/agent/${arn.value}/service/HMRC-MTD-IT/client/NI/${nino.value}"
       httpClient
         .get(requestUrl)
         .execute[HttpResponse]
@@ -60,7 +50,7 @@ class RelationshipsConnector @Inject() (httpClient: HttpClientV2, val metrics: M
     ec: ExecutionContext
   ): Future[Boolean] =
     monitor(s"ConsumedAPI-Check-ItsaSuppRelationship-GET") {
-      val requestUrl = checkItsaSuppRelationshipUrl(arn, nino)
+      val requestUrl = url"$acrUrl/agent/${arn.value}/service/HMRC-MTD-IT-SUPP/client/NI/${nino.value}"
       httpClient
         .get(requestUrl)
         .execute[HttpResponse]
@@ -69,7 +59,7 @@ class RelationshipsConnector @Inject() (httpClient: HttpClientV2, val metrics: M
 
   def checkVatRelationship(arn: Arn, vrn: Vrn)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Boolean] =
     monitor(s"ConsumedAPI-Check-VatRelationship-GET") {
-      val requestUrl = checkVatRelationshipUrl(arn, vrn)
+      val requestUrl = url"$acrUrl/agent/${arn.value}/service/HMRC-MTD-VAT/client/VRN/${vrn.value}"
       httpClient
         .get(requestUrl)
         .execute[HttpResponse]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -25,7 +25,7 @@ play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 
 # Json error handler
 play.http.errorHandler = "uk.gov.hmrc.agentauthorisation.ErrorHandler"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,12 +1,11 @@
-import play.core.PlayVersion
 import play.sbt.PlayImport.ws
-import sbt._
+import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion: String = "8.6.0"
+  private val bootstrapVersion: String = "9.11.0"
 
-  lazy val compileDeps = Seq(
+  lazy val compileDeps: Seq[ModuleID] = Seq(
     ws,
     "uk.gov.hmrc"             %% "bootstrap-frontend-play-30" % bootstrapVersion,
     "com.github.blemale"      %% "scaffeine"                  % "5.3.0",
@@ -15,12 +14,9 @@ object AppDependencies {
     "uk.gov.hmrc"             %% "play-hmrc-api-play-30"      % "8.0.0"
   )
 
-  val test  = Seq(
-    "org.scalatestplus.play"  %% "scalatestplus-play"         % "7.0.1"           % Test,
+  val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"             %% "bootstrap-test-play-30"     % bootstrapVersion  % Test,
-    "org.pegdown"             % "pegdown"                     % "1.6.0"           % Test,
-    "org.scalamock"           %% "scalamock"                  % "7.3.0"           % Test,
-    "com.vladsch.flexmark"    %  "flexmark-all"               % "0.64.8"          % Test
+    "org.scalamock"           %% "scalamock"                  % "7.3.0"           % Test
   )
 
 }


### PR DESCRIPTION
~~I had to manually encode the postcode that was sent as part of a URL path by replacing the whitespace with `%20`. It seems in V1 of HttpClient this was happening behind the scenes, whereas V2 throws an exception when you provide a URL with a whitespace char.~~ Comment no longer relevant